### PR TITLE
Non Persistent Instance property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.1.1] - 2022-06-21
+
+### Added
+
+- Singleton.NonPersistentInstance: a new instance that is destroyed during scene changes.
+
 ## [1.1.0] - 2022-06-14
 
 ### Added

--- a/Runtime/Singleton.cs
+++ b/Runtime/Singleton.cs
@@ -55,6 +55,9 @@ namespace UniEnt.Unity_QOL.Runtime {
         }
 
 
+        /// <summary>
+        ///     Create a singleton instance and attach to a dedicated GameObject.
+        /// </summary>
         static T CreateInstance(out GameObject singletonObject) {
             lock (SLock) {
                 // Search for existing instance.

--- a/Runtime/Singleton.cs
+++ b/Runtime/Singleton.cs
@@ -16,8 +16,9 @@ namespace UniEnt.Unity_QOL.Runtime {
 
         // ReSharper disable once MemberCanBeInternal
         /// <summary>
-        ///     Access singleton instance through this propriety.
+        ///     Access singleton instance through this property.
         /// </summary>
+        /// <remarks>This instance will persist across scene changes.</remarks>
         public static T Instance {
             get {
                 lock (SLock) {
@@ -38,6 +39,35 @@ namespace UniEnt.Unity_QOL.Runtime {
 
                     // Make instance persistent.
                     DontDestroyOnLoad(singletonObject);
+
+                    return _sInstance;
+                }
+            }
+        }
+
+
+        // ReSharper disable once MemberCanBeInternal
+        /// <summary>
+        ///     Access non persistent singleton instance through this property.
+        /// </summary>
+        /// <remarks>This instance will not persist across scene changes.</remarks>
+        public static T NonPersistentInstance {
+            get {
+                lock (SLock) {
+                    if (_sInstance != null)
+                        return _sInstance;
+
+                    // Search for existing instance.
+                    _sInstance = (T)FindObjectOfType(typeof(T));
+
+                    // Create new instance if one doesn't already exist.
+                    if (_sInstance != null)
+                        return _sInstance;
+
+                    // Need to create a new GameObject to attach the singleton to.
+                    var singletonObject = new GameObject();
+                    _sInstance = singletonObject.AddComponent<T>();
+                    singletonObject.name = typeof(T) + " (Singleton)";
 
                     return _sInstance;
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.unient.unity-qol",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "displayName": "Unity QOL",
     "description": "Universal Entities Quality of Life Unity Tools",
     "license": "MIT",


### PR DESCRIPTION
## This PR

- extends `Singleton` with accesses to `NonPersistentInstance`
- this instance is not persisted across scene changes via `DontDestroyOnLoad()`
- a regular persistent `Instance` is still available

## How to test

- see [corresponding PR](https://github.com/UE-Games/unient-unity-tools/pull/1) on `unient-unity-tools` for test scenario